### PR TITLE
Gave WiFi some time to get started, added retry loop to the connection

### DIFF
--- a/espRFID/UpdateACLTask.cpp
+++ b/espRFID/UpdateACLTask.cpp
@@ -15,7 +15,7 @@
 
 const int BUTTON_HOLD_TIME = 14000;
 
-#define DEBUG   //If you comment this line, the DPRINT & DPRINTLN lines are defined as blank.
+// #define DEBUG   //If you comment this line, the DPRINT & DPRINTLN lines are defined as blank.
 #ifdef DEBUG    //Macros are usually in all capital letters.
   #define DPRINT(...)    Serial.print(__VA_ARGS__)     //DPRINT is a macro, debug print
   #define DPRINTLN(...)  Serial.println(__VA_ARGS__)   //DPRINTLN is a macro, debug print with new line

--- a/espRFID/UpdateACLTask.h
+++ b/espRFID/UpdateACLTask.h
@@ -38,6 +38,8 @@ private:
 
   bool isAutomatedUpdate();
 
+  uint32_t retryCount;
+  uint32_t nextRetryInterval;
   uint32_t nextAutomatedTime;
   uint32_t automatedInterval;
   String lastUpdateLog;

--- a/espRFID/espRFID.ino
+++ b/espRFID/espRFID.ino
@@ -59,7 +59,6 @@ void setup() {
   Serial.println("I'm booting");
   SPIFFS.begin();
 
-//    WiFi.begin(ssid, password);
 }
 
 


### PR DESCRIPTION
May want to reevaluate the retry loop inside of HttpsRedirect at some point if we're going to do this. Fewer... Give it some back-off... something. 

Biggest issue I saw was that it immediately starts attempting to connect to google repeatedly before it's even connected to the wifi, and sometimes never connects to wifi. So I made it wait a bit before trying. 

Would like to send the logs to a rolling log on the space server at some point. May give us a better idea of what happens when we have problems AND will allow us to see usage statistics. (Or just how many times someone swipes before they realize they can get in on average. ¯\_(ツ)_/¯ ) 